### PR TITLE
Create join link to google group mailing list page 

### DIFF
--- a/src/views/index.html
+++ b/src/views/index.html
@@ -8,6 +8,7 @@
 
 <body>
 <a target="_blank" rel="noopener noreferrer" href="https://aggie-coding-club.slack.com">Join Slack</a>
+<a target="_blank" rel="noopener noreferrer" href="https://groups.google.com/forum/#!forum/aggiecodingclub">Join Mailing List</a>
 <a href="/about">Learn more about ACC!</a>
     <a href="/announcements">Announcements</a>
     See our Learning and Progress Oriented projects <a href="/projects">here!</a>


### PR DESCRIPTION
Adds a new link to google group on the home page.
Closes #87 